### PR TITLE
Fixes "undefined reference to `tputs' "

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,5 +49,6 @@ if (USE_KAHIP)
 endif()
 target_link_libraries(console PUBLIC ${READLINE})
 target_link_libraries(console PUBLIC ${TBB_LIBRARIES})
+target_link_libraries(console PUBLIC tinfo)
 
 


### PR DESCRIPTION
Without the change, I was get the following error on trying to compile:
``
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/8/../../../x86_64-linux-gnu/libreadline.a(terminal.o): in function `_rl_backspace': 
(.text+0xb9b): undefined reference to `tputs'
(.text+0xd98): more undefined references to `tputs' follow
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.    
``