### PR TITLE
Make Py scripts agnostic to console location; alphabetize imports

### DIFF
--- a/evaluation/flowcutter_order.py
+++ b/evaluation/flowcutter_order.py
@@ -1,11 +1,12 @@
-import subprocess
+import pathlib
 import re
+import subprocess
 import sys
 
 experiments_folder = ""
 
-binary_path = "./../build/"
-console = binary_path + "console"
+binary_path = pathlib.Path(__file__).parent.absolute() / "../build"
+console = str(binary_path / "console")
 
 def graph_path(G):
     return experiments_folder + G + "/"
@@ -47,7 +48,7 @@ def save_flowcutter_cch_order(console, ncutters, graph_path, order_path, info_lo
     #args.append("save_permutation_of_nodes_since_last_file_load")
     args.append("save_routingkit_node_permutation_since_last_load")
     args.append(order_path)
-    
+
     with open(info_log, 'w') as f:
         subprocess.run(args, universal_newlines=True, stdout=f)
 

--- a/evaluation/inertialflow_order.py
+++ b/evaluation/inertialflow_order.py
@@ -1,11 +1,12 @@
-import subprocess
+import pathlib
 import re
+import subprocess
 import sys
 
 experiments_folder = ""
 
-binary_path = "./../build/"
-console = binary_path + "console"
+binary_path = pathlib.Path(__file__).parent.absolute() / "../build"
+console = str(binary_path / "console")
 
 def graph_path(G):
     return experiments_folder + G + "/"
@@ -48,7 +49,7 @@ def save_inertial_flow_cch_order(console, graph_path, order_path, info_log):
 
     args.append("save_routingkit_node_permutation_since_last_load")
     args.append(order_path)
-    
+
     with open(info_log, 'w') as f:
         subprocess.run(args, universal_newlines=True, stdout=f)
 

--- a/evaluation/inertialflowcutter_order.py
+++ b/evaluation/inertialflowcutter_order.py
@@ -1,13 +1,13 @@
-import pandas as pd
-import numpy as np
+import pathlib
+import re
 import subprocess
 import sys
-import re
+
 
 experiments_folder = ""
 
-binary_path = "./../build/"
-console = binary_path + "console"
+binary_path = pathlib.Path(__file__).parent.absolute() / "../build"
+console = str(binary_path / "console")
 
 def order_path(G,P):
     return experiments_folder + G + "." + P + ".order"
@@ -83,6 +83,6 @@ def main():
     save_inertialflowcutter_cch_order(cutters, G)
     order_time = parse_order_log(G,P)["order_running_time"]
     print(P, G, round(order_time, 3), sep=',')
-            
+
 if __name__ == '__main__':
     main()

--- a/evaluation/kahip_order.py
+++ b/evaluation/kahip_order.py
@@ -1,11 +1,12 @@
-import subprocess
+import pathlib
 import re
+import subprocess
 import sys
 
 experiments_folder = ""
 
-binary_path = "./../build/"
-console = binary_path + "console"
+binary_path = pathlib.Path(__file__).parent.absolute() / "../build"
+console = str(binary_path / "console")
 
 def graph_path(G):
     return experiments_folder + G + "/"
@@ -31,7 +32,7 @@ def save_kahip_cch_order(console, graph_path, order_path, info_log):
     args.append("flow_cutter_set")
     args.append("random_seed")
     args.append("5489")
-    
+
     args.append("report_time")
     args.append("reorder_nodes_in_kahip_nested_dissection_order")
     args.append("0.2")   #maximum imbalance

--- a/evaluation/metis_order.sh
+++ b/evaluation/metis_order.sh
@@ -5,4 +5,3 @@ echo -n metis,$G,
 ./ndmetis tmp | grep "Ordering" | sed -E 's/^[ \t]*Ordering:[ \t]+([0-9.]+)[ \t]+sec[ \t]+\(METIS time\)[ \t]*$/\1/'
 ./../build/console load_routingkit_unweighted_graph $G/first_out $G/head permutate_nodes tmp.iperm save_routingkit_node_permutation_since_last_load $G.metis.order
 rm tmp tmp.iperm
-

--- a/evaluation/order_experiments.py
+++ b/evaluation/order_experiments.py
@@ -1,18 +1,21 @@
-import pandas as pd
-import numpy as np
+import os
+import pathlib
 import re
 import subprocess
-import os
+
+import pandas as pd
+import numpy as np
+
 
 experiments_folder = ""
 
 graphs = ["col", "cal", "europe", "usa"]
 partitioners = ["metis", "kahip_v0_71", "kahip_v1_00_cut", "kahip_v2_11", "inertial_flow", "flowcutter3", "flowcutter20", "flowcutter100","inertialflowcutter4", "inertialflowcutter8", "inertialflowcutter12", "inertialflowcutter16"]
 
-binary_path = "./../build/"
-console = binary_path + "console"
-customization_binary = binary_path + "customize"
-query_binary = binary_path + "query"
+binary_path = pathlib.Path(__file__).parent.absolute() / "../build"
+console = str(binary_path / "console")
+customization_binary = str(binary_path / "customize")
+query_binary = str(binary_path / "query")
 
 def config_contained(G, P, results):
     cpd = pd.DataFrame.from_dict({
@@ -42,13 +45,13 @@ def query_file(G):
 def parse_order_log(G,P):
     args = [console]
     args.append("load_routingkit_unweighted_graph")
-    
+
     args.append(graph_path(G) + "first_out")
     args.append(graph_path(G) + "head")
     args.append("add_back_arcs")
     args.append("remove_multi_arcs")
     args.append("remove_loops")
-    
+
     args.append("permutate_nodes_routingkit")
     args.append(order_path(G,P))
 
@@ -96,7 +99,7 @@ def run_queries(G,P):
     return float(t)
 
 def main():
-    
+
     order_times = pd.read_csv(experiments_folder + "order_running_time.csv")
 
     if not os.path.isfile(experiments_folder + "order_experiments.csv"):    #Create nonsensical file
@@ -138,7 +141,7 @@ def main():
     results.sort_values(["graph_id", "partitioner_id"], ascending=[True,True], inplace=True)
     results.drop(columns=["graph_id", "partitioner_id"])
     results.to_csv(experiments_folder + "order_experiments.csv", index=False)
-    
+
 
 
 if __name__ == '__main__':

--- a/evaluation/parameterstudy.py
+++ b/evaluation/parameterstudy.py
@@ -1,9 +1,12 @@
-import configurable_inertialflowcutter_order as ifc
-import pandas as pd
-import numpy as np
+import os
+import pathlib
 import re
 import subprocess
-import os
+
+import configurable_inertialflowcutter_order as ifc
+import numpy as np
+import pandas as pd
+
 
 experiments_folder = ""
 graph = "col"       #TODO replace again with europe
@@ -12,10 +15,10 @@ metric_path = graph_path + "travel_time"
 query_sources = experiments_folder + graph + ".q.s"
 query_targets = experiments_folder + graph + ".q.t"
 
-binary_path = "./../build/"
-order_console = binary_path + "console"
-customization_binary = binary_path + "customize"
-query_binary = binary_path + "query"
+binary_path = pathlib.Path(__file__).parent.absolute() / "../build"
+order_console = str(binary_path / "console")
+customization_binary = str(binary_path / "customize")
+query_binary = str(binary_path / "query")
 
 
 def config_contained(config, results):

--- a/evaluation/toplevel_cut_experiments.py
+++ b/evaluation/toplevel_cut_experiments.py
@@ -1,20 +1,22 @@
 import os
+import pathlib
 import re
-import pandas as pd
-import metis_cut as metis
-import kahip_cut as kahip
-import inertialflow_cut as inertialflow
+
 import flowcutter_cut as flowcutter
+import inertialflow_cut as inertialflow
 import inertialflowcutter_cut as ifc
+import kahip_cut as kahip
+import metis_cut as metis
+import pandas as pd
 
 experiments_folder = ""
 graphs = ["col", "cal", "europe", "usa"]
 partitioners = ["metis", "kahip_v2_11", "inertial_flow",  "flowcutter3", "flowcutter20", "inertialflowcutter4", "inertialflowcutter8", "inertialflowcutter12", "inertialflowcutter16"]
 imbalances = [0.0, 0.01, 0.03, 0.05, 0.1, 0.2, 0.3, 0.5, 0.7, 0.9]
 
-binary_path = "./../build/"
-console = binary_path + "console"
-metis_path = "./" + experiments_folder + "gpmetis" 
+binary_path = pathlib.Path(__file__).parent.absolute() / "../build"
+console = str(binary_path / "console")
+metis_path = "./" + experiments_folder + "gpmetis"
 
 def graph_path(G):
     return experiments_folder + G + "/"
@@ -80,7 +82,7 @@ def compute_inertial_flow_cuts(G):
     results = pd.DataFrame(rows)
     return results.set_index("epsilon").sort_index()
 
-def compute_flow_cutter_cuts(G, cutters): 
+def compute_flow_cutter_cuts(G, cutters):
     cuts = flowcutter.flowcutter_pareto(console, graph_path(G), cutters)
     node_count = cuts.iloc[-1]["small_side_size"] + cuts.iloc[-1]["large_side_size"]
     cuts['imbalance'] = cuts["large_side_size"] / ((node_count + 1) // 2) - 1
@@ -97,7 +99,7 @@ def compute_flow_cutter_cuts(G, cutters):
     results = pd.DataFrame(rows)
     return results.set_index("epsilon").sort_index()
 
-def compute_inertial_flow_cutter_cuts(G, cutters): 
+def compute_inertial_flow_cutter_cuts(G, cutters):
     cuts = ifc.inertialflowcutter_pareto(console, graph_path(G), cutters)
     node_count = cuts.iloc[-1]["small_side_size"] + cuts.iloc[-1]["large_side_size"]
     cuts['imbalance'] = cuts["large_side_size"] / ((node_count + 1) // 2) - 1


### PR DESCRIPTION
Currently the Python scripts must be run using either `src` or `evaluation` as the working directory. This is needlessly restrictive. This PR identifies the scripts' locations and uses the locations as the basis for finding the `console` program, thereby making it so the scripts can be run safely from anywhere.

I also arrange and alphabetize the imports to a more standard format.

The PR strips trailing whitespaces from the modified files. Most code editors can (and should) be configured to do this automatically when a file is saved.